### PR TITLE
fix(maturation): attribute endpoint-wide stalls and leaked ssh timeouts across trials

### DIFF
--- a/.agents/maturation/README.md
+++ b/.agents/maturation/README.md
@@ -61,13 +61,36 @@ stack when a run looks stalled.
   summary.md          anonymised summary, safe to paste into a PR
 ```
 
+## Report-time attribution
+
+Per-trial attribution is computed at run time from the full tool result and
+stored in `trials.jsonl` as-is. Two cross-trial passes run when the report is
+built — on a live run and on every `--report <run-id>` replay — so retained
+evidence benefits from attribution fixes without a new hardware pass:
+
+- `harness`-layer trials whose retained exception matches a current rule are
+  re-attributed (a leaked `TimeoutExpired` naming `ssh`/`ControlMaster`
+  becomes `transport`).
+- ≥ 3 consecutive trials on one endpoint that all time out at ≥ 95 % of
+  their budget, across any operations, become `transport-stall`: the
+  endpoint's shared channel is dead, the operations are not implicated. The
+  episodes are listed under `summary.stall_episodes`.
+
+Relabelled rows keep `original_layer`. A replay also prunes candidate files
+that the latest pass did not produce.
+
 ## Knowledge feedback
 
 A failure that reproduces at least `--min-reproductions` times (default 2)
 with the same (operation, layer, fingerprint) becomes a redacted
-`known-failure-signatures` candidate. With `--capture-knowledge` the harness
-hands it to `.agents/scripts/knowledge_capture.py` as a CLI contract and
-reports the script's verdict; a non-JSON or status-less reply is reported as
+`known-failure-signatures` candidate; `transport-stall` trials are grouped
+into one candidate per fingerprint regardless of operation. A group whose
+every repetition failed on each affected endpoint and nowhere else is marked
+"deterministic per environment" with `medium` confidence, because the
+aggregate pass rate is then an environment mix, not flakiness. With
+`--capture-knowledge` the harness hands each candidate to
+`.agents/scripts/knowledge_capture.py` as a CLI contract and reports the
+script's verdict; a non-JSON or status-less reply is reported as
 `contract-drift`, never patched around.
 
 ## Layout

--- a/.agents/maturation/attribution.py
+++ b/.agents/maturation/attribution.py
@@ -17,6 +17,7 @@ LAYERS = (
     "tool-service",  # the tool returned instantly/without a parsable result
     "tool-helper",  # the tool's own remote helper or wrapper code failed
     "timeout",  # a genuine deadline expiry
+    "transport-stall",  # consecutive full-budget timeouts on one endpoint (dead shared channel)
     "remote-command",  # the remote command ran and exited non-zero
     "path-policy",  # blocked by root/cwd/symlink policy
     "integrity",  # hash mismatch, partial or leftover state
@@ -185,6 +186,121 @@ def _leaked_timeout(exception: str) -> dict[str, Any] | None:
         "reason": "TimeoutExpired leaked from the tool instead of a result payload",
         "fingerprint": "timeout leaked from tool",
     }
+
+
+def refresh_exception_attribution(trials: list[dict[str, Any]]) -> int:
+    """Re-run exception attribution for trials stored at the ``harness`` layer.
+
+    The exception text is retained verbatim in the evidence, so a replay can
+    apply the current exception rules (for example the leaked-ssh-timeout
+    rule) to runs recorded before those rules existed. Result-based
+    attribution is *not* recomputed here because the retained ``raw`` record
+    is a reduced view of the tool result. Returns the number of trials changed.
+    """
+    changed = 0
+    for trial in trials:
+        attribution = trial.get("attribution") or {}
+        if trial.get("passed") or attribution.get("layer") != "harness":
+            continue
+        step = next((s for s in trial.get("steps") or [] if not s.get("passed")), None)
+        if not step or not step.get("exception"):
+            continue
+        fresh = attribute(
+            None,
+            expectation_error=step.get("expectation_error"),
+            duration_ms=step.get("duration_ms"),
+            timeout_ms=step.get("timeout_ms"),
+            exception=str(step["exception"]),
+            op_class=str(trial.get("op_class") or ""),
+        )
+        if fresh["layer"] == "harness":
+            continue
+        fresh["step"] = attribution.get("step") or step.get("name")
+        fresh["original_layer"] = "harness"
+        trial["attribution"] = fresh
+        changed += 1
+    return changed
+
+
+STALL_MIN_CONSECUTIVE = 3
+STALL_BUDGET_RATIO = 0.95
+
+
+def reclassify_endpoint_stalls(
+    trials: list[dict[str, Any]],
+    *,
+    min_consecutive: int = STALL_MIN_CONSECUTIVE,
+) -> list[dict[str, Any]]:
+    """Relabel runs of full-budget timeouts on one endpoint as a transport stall.
+
+    A single timeout is a per-command fault. Every command on one endpoint
+    timing out at its full budget, back to back, across several different
+    operations, is not: it is the shared SSH channel for that endpoint being
+    dead while its socket still exists (the recorded ControlMaster signature).
+    Reporting those as per-operation timeouts makes healthy operations look
+    flaky and hides the real fault, so they are attributed to the endpoint.
+
+    Returns the list of stall episodes; the trials are annotated in place.
+    """
+    by_endpoint: dict[str, list[dict[str, Any]]] = {}
+    for trial in trials:
+        by_endpoint.setdefault(str(trial.get("endpoint_label")), []).append(trial)
+    episodes: list[dict[str, Any]] = []
+    for label, items in by_endpoint.items():
+        items.sort(key=lambda t: (str(t.get("started_at")), int(t.get("attempt") or 0)))
+        run: list[dict[str, Any]] = []
+        for trial in [*items, None]:
+            if trial is not None and _is_full_budget_timeout(trial):
+                run.append(trial)
+                continue
+            if len(run) >= min_consecutive:
+                episodes.append(_mark_stall(label, run))
+            run = []
+    return episodes
+
+
+def _is_full_budget_timeout(trial: Mapping[str, Any]) -> bool:
+    attribution = trial.get("attribution") or {}
+    if trial.get("passed") or attribution.get("layer") != "timeout":
+        return False
+    for step in trial.get("steps") or []:
+        if step.get("passed"):
+            continue
+        raw = step.get("raw") or {}
+        budget = step.get("timeout_ms") or raw.get("timeout_ms")
+        duration = step.get("duration_ms")
+        if isinstance(budget, (int, float)) and isinstance(duration, (int, float)):
+            return duration >= budget * STALL_BUDGET_RATIO
+    return True
+
+
+def _mark_stall(label: str, run: list[dict[str, Any]]) -> dict[str, Any]:
+    operations = sorted({str(t.get("operation_id")) for t in run})
+    episode = {
+        "endpoint_label": label,
+        "trials": len(run),
+        "operations": operations,
+        "started_at": str(run[0].get("started_at")),
+        "ended_at": str(run[-1].get("started_at")),
+        "duration_ms": sum(int(t.get("duration_ms") or 0) for t in run),
+        "trial_ids": [str(t.get("trial_id")) for t in run],
+    }
+    reason = (
+        f"endpoint-wide stall: {len(run)} consecutive full-budget timeouts on {label} "
+        f"spanning {len(operations)} operation(s) between {episode['started_at']} and "
+        f"{episode['ended_at']}. Every command timing out at its full budget, across "
+        "different operations, is the shared SSH channel being dead while its socket "
+        "still exists — not a fault of the operations involved."
+    )
+    for trial in run:
+        attribution = dict(trial.get("attribution") or {})
+        attribution["original_layer"] = attribution.get("layer")
+        attribution["layer"] = "transport-stall"
+        attribution["reason"] = reason
+        attribution["fingerprint"] = "endpoint-wide consecutive full-budget timeouts stale ssh mux"
+        attribution["stall_episode"] = f"{label}@{episode['started_at']}"
+        trial["attribution"] = attribution
+    return episode
 
 
 _HEX_RE = re.compile(r"\b[0-9a-f]{12,}\b", re.IGNORECASE)

--- a/.agents/maturation/evidence.py
+++ b/.agents/maturation/evidence.py
@@ -72,6 +72,19 @@ class EvidenceStore:
         atomic_write_json(path, candidate)
         return path
 
+    def prune_candidates(self, keep_ids: set[str]) -> list[str]:
+        """Drop candidate files not produced by the latest finalize.
+
+        A replay re-derives candidates from the trials; files left over from an
+        earlier attribution pass would otherwise misrepresent the run.
+        """
+        removed: list[str] = []
+        for path in (self.run_dir / "candidates").glob("*.json"):
+            if path.stem not in keep_ids:
+                path.unlink()
+                removed.append(path.stem)
+        return removed
+
     def write_run(self, report: Mapping[str, Any]) -> Path:
         path = self.run_dir / "run.json"
         atomic_write_json(path, report)

--- a/.agents/maturation/knowledge.py
+++ b/.agents/maturation/knowledge.py
@@ -22,6 +22,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 CAPTURE_SCRIPT = REPO_ROOT / ".agents" / "scripts" / "knowledge_capture.py"
 OWNER_SKILL = "remote-toolbox"
 MIN_REPRODUCTIONS = 2
+STALL_GROUP = "endpoint.transport_stall"
 
 
 def group_failures(trials: Iterable[Mapping[str, Any]]) -> dict[tuple[str, str, str], list[Mapping[str, Any]]]:
@@ -31,11 +32,11 @@ def group_failures(trials: Iterable[Mapping[str, Any]]) -> dict[tuple[str, str, 
         if trial.get("passed"):
             continue
         attribution = trial.get("attribution") or {}
-        key = (
-            str(trial.get("operation_id")),
-            str(attribution.get("layer") or "unknown"),
-            str(attribution.get("fingerprint") or ""),
-        )
+        layer = str(attribution.get("layer") or "unknown")
+        # An endpoint-wide stall is one fault regardless of which operations
+        # were scheduled while the channel was dead; group it as such.
+        op_key = STALL_GROUP if layer == "transport-stall" else str(trial.get("operation_id"))
+        key = (op_key, layer, str(attribution.get("fingerprint") or ""))
         groups[key].append(trial)
     return groups
 
@@ -50,14 +51,18 @@ def build_candidates(
 ) -> list[dict[str, Any]]:
     """One candidate per reproducible (operation, layer, fingerprint) group."""
     totals: dict[str, int] = defaultdict(int)
+    per_endpoint_totals: dict[tuple[str, str], int] = defaultdict(int)
     for trial in trials:
         totals[str(trial.get("operation_id"))] += 1
+        per_endpoint_totals[(str(trial.get("operation_id")), str(trial.get("endpoint_label")))] += 1
     candidates: list[dict[str, Any]] = []
     for (op_id, layer, fingerprint), failures in sorted(group_failures(trials).items()):
         if len(failures) < min_reproductions:
             continue
         sample = failures[0]
-        n = totals[op_id]
+        is_stall = op_id == STALL_GROUP
+        affected_ops = sorted({str(t.get("operation_id")) for t in failures})
+        n = sum(totals[op] for op in affected_ops) if is_stall else totals[op_id]
         labels = sorted({str(t.get("endpoint_label")) for t in failures})
         kinds = sorted({str(t.get("endpoint_kind")) for t in failures})
         pythons = sorted({str((t.get("environment") or {}).get("remote_python") or "unknown") for t in failures})
@@ -66,32 +71,81 @@ def build_candidates(
         step = str((sample.get("attribution") or {}).get("step") or "")
         durations = [int(t.get("duration_ms") or 0) for t in failures]
         all_fail = len(failures) == n
-        payload = {
-            "kind": "known-failure-signatures",
-            "summary": f"{op_id} fails at the {layer} layer under the maturation harness",
-            "owner_skill": OWNER_SKILL,
-            "scope": {
-                "component": str(sample.get("tool") or op_id),
-                "environment": f"maturation-harness/{'+'.join(kinds)}",
-                "subsystem": layer,
-                "shape": str(sample.get("shape") or ""),
-            },
-            "fingerprints": [item for item in (fingerprint, f"maturation {op_id} {layer}") if item],
-            "symptom": (
+        # Deterministic *per environment*: every repetition failed on each
+        # endpoint where any failed. The aggregate rate then hides a hard
+        # failure behind a "flaky" label, so say so explicitly.
+        per_endpoint_failures: dict[str, int] = defaultdict(int)
+        for t in failures:
+            per_endpoint_failures[str(t.get("endpoint_label"))] += 1
+        env_deterministic = (
+            not is_stall
+            and not all_fail
+            and all(per_endpoint_failures[label] == per_endpoint_totals[(op_id, label)] for label in labels)
+        )
+        if is_stall:
+            episodes = sorted({str((t.get("attribution") or {}).get("stall_episode") or "") for t in failures})
+            summary_text = "shared SSH channel stalls endpoint-wide under the maturation harness"
+            symptom = (
+                f"{len(episodes)} stall episode(s) on {len(labels)} endpoint(s) {', '.join(labels)}: "
+                f"{len(failures)} consecutive trials across {len(affected_ops)} unrelated operations "
+                f"({', '.join(affected_ops)}) all timed out at their full budget "
+                f"({min(durations)}-{max(durations)} ms), then the endpoint recovered without intervention. "
+                f"Attribution: {reason}"
+            )
+            root_cause = (
+                "Consistent with the recorded ControlMaster signature: the multiplexed master for the endpoint "
+                "is dead or wedged while its ControlPath socket still exists, so every new client attaches to "
+                "the stale socket and waits out its full timeout. The per-command error text "
+                "('remote python timed out') attributes the fault to the remote host, which is wrong. "
+                "Confirm by correlating the episode start with the preceding CLI-spawned or SIGKILLed ssh process."
+            )
+            resolution = (
+                "Pending. Candidate fixes to validate: (1) have the transport detect N consecutive full-budget "
+                "timeouts on one endpoint and remove the stale ControlPath socket, (2) have wrappers that kill "
+                "ssh processes never kill the master (or reap the socket afterwards), "
+                "(3) report the stall as a transport fault rather than a remote timeout."
+            )
+        else:
+            summary_text = f"{op_id} fails at the {layer} layer under the maturation harness"
+            symptom = (
                 f"{len(failures)} of {n} repetitions of {op_id} ({sample.get('shape')}) failed on "
                 f"{len(labels)} endpoint(s) {', '.join(labels)}; statuses {', '.join(statuses)}; "
                 f"failing step {step or 'call'}; failure durations {min(durations)}-{max(durations)} ms. "
                 f"Attribution: {reason}"
-            ),
-            "root_cause": (
+            )
+            if all_fail:
+                determinism = "Every repetition failed, so this is a deterministic failure, not a flake. "
+            elif env_deterministic:
+                determinism = (
+                    f"Deterministic per environment: every repetition failed on each of the {len(labels)} affected "
+                    f"endpoint(s) and none failed elsewhere (remote python {', '.join(pythons)}). The aggregate pass "
+                    "rate is an environment mix, not flakiness. "
+                )
+            else:
+                determinism = "Intermittent (flake): some repetitions passed on the same endpoint. "
+            root_cause = (
                 f"Not yet attributed below the {layer} layer. "
-                + ("Every repetition failed, so this is a deterministic failure, not a flake. " if all_fail else "Intermittent (flake): some repetitions passed. ")
+                + determinism
                 + "Inspect the raw trial output in the evidence directory before promoting."
-            ),
-            "resolution": (
+            )
+            resolution = (
                 f"Pending. Reproduce with `python3 .agents/maturation/run.py --operation {op_id}` against the same "
                 "endpoint kind, then attach the confirmed cause and fix before promotion."
-            ),
+            )
+        payload = {
+            "kind": "known-failure-signatures",
+            "summary": summary_text,
+            "owner_skill": OWNER_SKILL,
+            "scope": {
+                "component": "ssh-transport" if is_stall else str(sample.get("tool") or op_id),
+                "environment": f"maturation-harness/{'+'.join(kinds)}",
+                "subsystem": layer,
+                "shape": "endpoint-stall" if is_stall else str(sample.get("shape") or ""),
+            },
+            "fingerprints": [item for item in (fingerprint, f"maturation {op_id} {layer}") if item],
+            "symptom": symptom,
+            "root_cause": root_cause,
+            "resolution": resolution,
             "avoidance": "Treat the pass rate, not a single green run, as the maturity signal for this operation.",
             "applicable_versions": (
                 f"maturation run {run_id}; endpoint kinds {', '.join(kinds)}; remote python {', '.join(pythons)}"
@@ -104,7 +158,7 @@ def build_candidates(
                 {"kind": "maturation-trials", "uri": f"{evidence_relative_dir}/trials.jsonl", "stable": False},
                 {"kind": "maturation-report", "uri": f"{evidence_relative_dir}/run.json", "stable": False},
             ],
-            "confidence": "medium" if all_fail else "low",
+            "confidence": "medium" if (all_fail or env_deterministic or is_stall) else "low",
             "source": {"run_ids": [run_id]},
         }
         payload = redactor.value(payload)

--- a/.agents/maturation/runner.py
+++ b/.agents/maturation/runner.py
@@ -19,6 +19,7 @@ from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Any, Callable, Mapping
 
+from .attribution import reclassify_endpoint_stalls, refresh_exception_attribution
 from .evidence import EvidenceStore
 from .invoke import Invoker
 from .knowledge import build_candidates, capture_candidate
@@ -332,6 +333,7 @@ def finalize(
     run_id: str,
     started_at: str,
     duration_ms: int,
+    finished_at: str | None = None,
 ) -> dict[str, Any]:
     """Aggregate trials, prepare/capture knowledge candidates, write the report.
 
@@ -340,7 +342,22 @@ def finalize(
     """
     redactor = Redactor.for_endpoints(endpoints)
     trials = store.load_trials()
+    # Retained exceptions are re-attributed with the current rules so replays
+    # of older runs benefit from attribution fixes.
+    refreshed = refresh_exception_attribution(trials)
+    if refreshed:
+        emit_progress("attribution", f"{refreshed} harness-layer trial(s) re-attributed from their retained exception")
+    # Cross-trial attribution: a run of full-budget timeouts on one endpoint is
+    # the endpoint's channel, not the operations that happened to be scheduled.
+    stalls = reclassify_endpoint_stalls(trials)
+    for episode in stalls:
+        emit_progress(
+            "attribution",
+            f"{episode['endpoint_label']}: {episode['trials']} consecutive full-budget timeouts "
+            f"reattributed to transport-stall ({', '.join(episode['operations'])})",
+        )
     summary = aggregate(trials, operation_set.classes)
+    summary["stall_episodes"] = stalls
     failures = [
         {
             "trial_id": t["trial_id"],
@@ -367,6 +384,7 @@ def finalize(
         min_reproductions=config.min_reproductions,
     )
     knowledge: dict[str, Any] = {"candidates_prepared": [], "captured": [], "capture_requested": config.capture_knowledge}
+    written_ids: set[str] = set()
     for candidate in candidates:
         # Give the candidate a stable id for the evidence file name; the capture
         # path recomputes/validates its own id from the semantic fields.
@@ -374,16 +392,21 @@ def finalize(
             (candidate["summary"] + "|" + "|".join(candidate["fingerprints"])).encode("utf-8")
         ).hexdigest()[:12]
         store.write_candidate({**candidate, "candidate_id": f"maturation-{preview_id}"})
+        written_ids.add(f"maturation-{preview_id}")
         knowledge["candidates_prepared"].append({"summary": candidate["summary"], "fingerprints": candidate["fingerprints"], "confidence": candidate["confidence"]})
         if config.capture_knowledge:
             emit_progress("knowledge", f"capturing candidate: {candidate['summary']}")
             knowledge["captured"].append({"summary": candidate["summary"], **capture_candidate(candidate, extra_args=config.capture_extra_args)})
+    pruned = store.prune_candidates(written_ids)
+    if pruned:
+        emit_progress("knowledge", f"pruned {len(pruned)} stale candidate file(s) from an earlier attribution pass")
 
     report = {
         "schema_version": "vaws.maturation-report.v1",
         "run_id": run_id,
         "started_at": started_at,
-        "finished_at": utc_now_iso(),
+        "finished_at": finished_at or utc_now_iso(),
+        "reported_at": utc_now_iso(),
         "duration_ms": duration_ms,
         "operations_source": _relative(operation_set.source),
         "config": {
@@ -435,6 +458,7 @@ def replay(
         run_id=run_id,
         started_at=str(previous.get("started_at") or ""),
         duration_ms=int(previous.get("duration_ms") or 0),
+        finished_at=str(previous.get("finished_at") or "") or None,
     )
 
 
@@ -483,6 +507,16 @@ def render_markdown(report: Mapping[str, Any]) -> str:
     lines += ["", "## Least mature first", ""]
     for index, item in enumerate(summary.get("ranking", [])[:15], start=1):
         lines.append(f"{index}. `{item['operation_id']}` — {item['verdict']} ({_pct(item.get('pass_rate'))}, n={item.get('n')}) {item.get('failure_layers') or ''}")
+    stalls = summary.get("stall_episodes") or []
+    if stalls:
+        lines += ["", f"## Endpoint stalls ({len(stalls)})", ""]
+        for episode in stalls:
+            lines.append(
+                f"- `{episode['endpoint_label']}`: {episode['trials']} consecutive full-budget timeouts, "
+                f"{episode['started_at']} → {episode['ended_at']} ({episode['duration_ms'] // 1000}s), "
+                f"operations affected: {', '.join(f'`{op}`' for op in episode['operations'])}. "
+                "Reattributed to `transport-stall`; the operations themselves are not implicated."
+            )
     failures = report.get("failures", [])
     lines += ["", f"## Failures ({len(failures)})", ""]
     for item in failures[:60]:

--- a/.agents/maturation/scenarios.py
+++ b/.agents/maturation/scenarios.py
@@ -200,6 +200,7 @@ class Step:
             "passed": self.passed,
             "expectation_error": self.expectation_error,
             "exception": self.exception,
+            "timeout_ms": self.timeout_ms,
             "raw": _raw_from_result(self.payload, self.result),
         }
         if self.extra:

--- a/.agents/tests/test_maturation_harness.py
+++ b/.agents/tests/test_maturation_harness.py
@@ -349,6 +349,88 @@ class AttributionTests(unittest.TestCase):
         self.assertIn("instant timeout", instant["reason"])
         self.assertEqual(instant["fingerprint"], "instant timeout any command")
 
+    @staticmethod
+    def _timeout_trial(label: str, op: str, started: str, attempt: int = 0, *, passed: bool = False, duration: int = 30004) -> dict[str, Any]:
+        layer = "timeout" if not passed else None
+        return {
+            "trial_id": f"{label}-{op}-{attempt}",
+            "endpoint_label": label,
+            "operation_id": op,
+            "attempt": attempt,
+            "started_at": started,
+            "duration_ms": duration,
+            "passed": passed,
+            "attribution": None if passed else {"layer": layer, "reason": "timed out", "fingerprint": "timeout timeout"},
+            "steps": [{"name": "call", "passed": passed, "duration_ms": duration, "timeout_ms": 30000, "raw": {}}],
+        }
+
+    def test_consecutive_full_budget_timeouts_become_transport_stall(self) -> None:
+        t = self._timeout_trial
+        trials = [
+            t("host-d", "multi_session.bash", "2026-09-07T10:07:31Z", 3),
+            t("host-d", "multi_session.read", "2026-09-07T10:08:31Z", 0),
+            t("host-d", "read.seed", "2026-09-07T10:09:01Z", 0),
+            t("host-d", "read.seed", "2026-09-07T10:09:31Z", 1),
+            t("host-d", "glob.seed", "2026-09-07T10:10:01Z", 0, passed=True, duration=120),
+            # An isolated timeout elsewhere must stay a per-command timeout.
+            t("host-b", "read.seed", "2026-09-07T10:09:01Z", 4),
+            t("host-b", "read.seed", "2026-09-07T10:09:31Z", 5, passed=True, duration=200),
+            # Two in a row is below the threshold.
+            t("host-c", "ls.seed", "2026-09-07T10:09:01Z", 0),
+            t("host-c", "ls.seed", "2026-09-07T10:09:31Z", 1),
+        ]
+        episodes = attribution.reclassify_endpoint_stalls(trials)
+        self.assertEqual(len(episodes), 1)
+        episode = episodes[0]
+        self.assertEqual(episode["endpoint_label"], "host-d")
+        self.assertEqual(episode["trials"], 4)
+        self.assertEqual(episode["operations"], ["multi_session.bash", "multi_session.read", "read.seed"])
+        stalled = [x for x in trials if x["endpoint_label"] == "host-d" and not x["passed"]]
+        for trial in stalled:
+            self.assertEqual(trial["attribution"]["layer"], "transport-stall")
+            self.assertEqual(trial["attribution"]["original_layer"], "timeout")
+            self.assertEqual(trial["attribution"]["fingerprint"], "endpoint-wide consecutive full-budget timeouts stale ssh mux")
+        for trial in trials:
+            if trial["endpoint_label"] in {"host-b", "host-c"} and not trial["passed"]:
+                self.assertEqual(trial["attribution"]["layer"], "timeout")
+
+    def test_refresh_reattributes_retained_leaked_ssh_timeout(self) -> None:
+        exc = "TimeoutExpired: Command '['ssh', '-o', 'ControlMaster=auto', 'root@192.0.2.9', 'bash']' timed out after 210 seconds"
+        trial = {
+            "passed": False,
+            "op_class": "recovery",
+            "attribution": {"layer": "harness", "reason": exc, "fingerprint": "x", "step": "rerun-pull"},
+            "steps": [{"name": "rerun-pull", "passed": False, "exception": exc, "duration_ms": 214000, "timeout_ms": None}],
+        }
+        untouched = {"passed": False, "attribution": {"layer": "harness", "reason": "RuntimeError: boom"}, "steps": [{"name": "call", "passed": False, "exception": "RuntimeError: boom"}]}
+        self.assertEqual(attribution.refresh_exception_attribution([trial, untouched]), 1)
+        self.assertEqual(trial["attribution"]["layer"], "transport")
+        self.assertEqual(trial["attribution"]["original_layer"], "harness")
+        self.assertEqual(trial["attribution"]["step"], "rerun-pull")
+        self.assertNotIn("192.0.2.9", trial["attribution"]["reason"])
+        self.assertEqual(untouched["attribution"]["layer"], "harness")
+
+    def test_short_timeouts_do_not_form_a_stall(self) -> None:
+        t = self._timeout_trial
+        trials = [t("host-a", "read.seed", f"2026-09-07T10:0{i}:00Z", i, duration=5000) for i in range(5)]
+        self.assertEqual(attribution.reclassify_endpoint_stalls(trials), [])
+        self.assertTrue(all(x["attribution"]["layer"] == "timeout" for x in trials))
+
+    def test_stall_trials_group_into_one_candidate(self) -> None:
+        t = self._timeout_trial
+        trials = [t("host-d", op, f"2026-09-07T10:0{i}:00Z", i) for i, op in enumerate(["read.seed", "ls.seed", "multi_session.read"])]
+        trials += [t("host-d", "glob.seed", "2026-09-07T10:09:00Z", 0, passed=True, duration=100)]
+        attribution.reclassify_endpoint_stalls(trials)
+        redactor = redact.Redactor.for_endpoints([])
+        candidates = knowledge.build_candidates(trials, run_id="r", evidence_relative_dir=".vaws-local/x", redactor=redactor)
+        self.assertEqual(len(candidates), 1)
+        candidate = candidates[0]
+        self.assertEqual(candidate["scope"]["component"], "ssh-transport")
+        self.assertEqual(candidate["scope"]["subsystem"], "transport-stall")
+        self.assertIn("ls.seed", candidate["symptom"])
+        self.assertIn("ControlMaster", candidate["root_cause"])
+        self.assertEqual(candidate["confidence"], "medium")
+
 
 class StatsTests(unittest.TestCase):
     def test_wilson_bound(self) -> None:
@@ -570,6 +652,17 @@ class KnowledgeTests(unittest.TestCase):
         self.assertEqual(candidate["confidence"], "low")
         self.assertEqual(candidate["verification"]["status"], "inconclusive")
         self.assertEqual(candidate["source"], {"run_ids": ["r"]})
+
+    def test_candidate_recognises_per_environment_determinism(self) -> None:
+        trials = [t for t in self._failing_trials() if t["operation_id"] == "glob.seed" and not t["passed"]]
+        # Same operation, all green on a second endpoint with a newer python.
+        for index in range(4):
+            trials.append({**trials[0], "trial_id": f"r-host-c-glob.seed-{index:03d}", "endpoint_label": "host-c", "passed": True, "attribution": None, "environment": {"remote_python": "3.12.3"}})
+        redactor = redact.Redactor.for_endpoints([{"label": "host-b", "host": "192.0.2.5", "port": 22}])
+        candidate = knowledge.build_candidates(trials, run_id="r", evidence_relative_dir=".vaws-local/x", redactor=redactor)[0]
+        self.assertEqual(candidate["confidence"], "medium")
+        self.assertIn("Deterministic per environment", candidate["root_cause"])
+        self.assertIn("4 of 8 repetitions", candidate["symptom"])
 
     def test_candidate_passes_the_real_capture_cli_contract(self) -> None:
         redactor = redact.Redactor.for_endpoints([{"label": "host-b", "host": "192.0.2.5", "port": 22}])

--- a/docs/deterministic-core-maturation.md
+++ b/docs/deterministic-core-maturation.md
@@ -107,6 +107,7 @@ remote Python, hostname digest), the raw output tail, the timing, and a layer:
 | `tool-service` | no parsable result, or a "timeout" that returned in < 25 % of its budget (the recorded *instant timeout* signature) |
 | `tool-helper` | the tool's own remote helper script or wrapper code failed (`remote python failed`, `exception`) |
 | `timeout` | the deadline genuinely expired |
+| `transport-stall` | cross-trial: ≥ 3 consecutive trials on one endpoint, spanning unrelated operations, all timing out at ≥ 95 % of their budget — the endpoint's shared channel is dead, the operations are not implicated |
 | `remote-command` | the command ran and exited non-zero |
 | `path-policy` | blocked by root / cwd / symlink policy |
 | `integrity` | hash mismatch, leftover temp files, partial state |
@@ -114,6 +115,14 @@ remote Python, hostname digest), the raw output tail, the timing, and a layer:
 | `environment` | an endpoint fact violated (hostname mapping, interpreter) |
 | `contract` | tool reported success but the declared expectation failed |
 | `harness` | the harness itself raised |
+
+Per-trial attribution happens at run time from the full tool result.
+Two cross-trial passes then run at report time (and on every
+`--report <run-id>` replay of retained evidence): trials stored as
+`harness` whose retained exception matches a current rule are
+re-attributed (a leaked `TimeoutExpired` naming `ssh`/`ControlMaster`
+becomes `transport`), and runs of full-budget timeouts become
+`transport-stall`. Both keep `original_layer` so the relabel is visible.
 
 ### 1.5 Evidence and feedback
 
@@ -134,13 +143,20 @@ from `.agents/maturation/operations.yaml`, endpoint parallelism 4, default
 repetitions, no `--max-load` filter. **No endpoint was skipped.** Eight
 endpoints ran the full 31-operation plan (277 trials each).
 
-**2216 trials, 2094 passes, 122 failures (94.5 % overall).** Recorded
-failure layers: `tool-helper` 60, `timeout` 37, `environment` 14,
-`integrity` 9, `harness` 2. The two `harness` labels are a harness defect
-in the retained evidence (see 2.4): `remote.artifact_pull` leaked
-`TimeoutExpired` on a wedged ControlMaster instead of returning a payload.
-The attribution code now maps that shape to `transport`. The `run.json`
-was not rewritten and no second hardware pass was run.
+**2216 trials, 2094 passes, 122 failures (94.5 % overall).** Failure
+layers after the report-time passes: `tool-helper` 60,
+`transport-stall` 33, `environment` 14, `integrity` 9, `timeout` 4,
+`transport` 2.
+
+At run time the same 122 failures were labelled `tool-helper` 60,
+`timeout` 37, `environment` 14, `integrity` 9, `harness` 2. Two changes
+came out of reading the evidence: 33 of the 37 "timeouts" were one
+uninterrupted 16-minute episode on a single host (§2.4) and are now
+`transport-stall`; the two `harness` rows were `remote.artifact_pull`
+leaking `TimeoutExpired` on a wedged ControlMaster and are now
+`transport`. Trials were not edited — `trials.jsonl` still carries the
+run-time labels and the report keeps `original_layer` on every relabelled
+row. No second hardware pass was run.
 
 ### 2.1 Endpoints
 
@@ -169,14 +185,16 @@ exception). Teardown succeeded on every endpoint.
 | transfer | 120 | 120 | 100.0 % | 96.9 % | — |
 | patch | 160 | 160 | 100.0 % | 97.7 % | — |
 | jobs | 96 | 96 | 100.0 % | 96.2 % | — |
-| file_ops | 560 | 534 | 95.4 % | 93.3 % | timeout 26 |
-| concurrency | 120 | 113 | 94.2 % | 88.5 % | timeout 7 |
+| file_ops | 560 | 534 | 95.4 % | 93.3 % | transport-stall 26 |
+| concurrency | 120 | 113 | 94.2 % | 88.5 % | transport-stall 7 |
 | environment | 160 | 146 | 91.3 % | 85.9 % | environment 14 |
-| recovery | 128 | 113 | 88.3 % | 81.6 % | integrity 9, timeout 4, harness 2 |
+| recovery | 128 | 113 | 88.3 % | 81.6 % | integrity 9, timeout 4, transport 2 |
 | search | 320 | 260 | 81.3 % | 76.6 % | tool-helper 60 |
 
-Transport, stream, transfer, patch, and jobs had zero failures. Search
-and recovery are the classes that are not ready to consolidate.
+Transport, stream, transfer, patch, and jobs had zero failures. Every
+`file_ops` and `concurrency` failure is the one host-d stall; outside
+that episode both classes were 100 %. Search, recovery, and the
+environment check are the classes with failures of their own.
 
 ### 2.3 Per operation
 
@@ -228,80 +246,99 @@ dir is untracked):
 ```
 # Maturation run `pass-1`
 - trials: 2216  passes: 2094  failures: 122  pass rate: 94.5%
-- failure layers: {'tool-helper': 60, 'integrity': 9,
-  'environment': 14, 'harness': 2, 'timeout': 37}
+- failure layers: {'tool-helper': 60, 'integrity': 9, 'environment': 14,
+  'transport': 2, 'transport-stall': 33, 'timeout': 4}
 
 ## Least mature first
 1. glob.seed — flaky (62.5%, n=160) {'tool-helper': 60}
 2. env.hostname_mapping — flaky (65.0%, n=40) {'environment': 14}
-3. artifact.interrupted_pull_transport — flaky (81.2%, n=32)
-4. artifact.interrupted_push_wrapper — flaky (87.5%, n=32)
-5. multi_session.read — flaky (87.5%, n=40) {'timeout': 5}
+3. artifact.interrupted_pull_transport — flaky (81.2%, n=32) {'transport': 1, 'integrity': 5}
+4. artifact.interrupted_push_wrapper — flaky (87.5%, n=32) {'integrity': 2, 'timeout': 2}
+5. multi_session.read — flaky (87.5%, n=40) {'transport-stall': 5}
+
+## Endpoint stalls (1)
+- host-d: 33 consecutive full-budget timeouts, 10:07:31Z → 10:23:31Z
+  (990s), operations affected: ls.seed, multi_session.bash,
+  multi_session.read, read.seed. Reattributed to transport-stall.
 ```
 
 ### 2.4 Failures, with layer attribution
 
-122 failures collapse into ten groups. Counts are from the retained
-`run.json`; the two `harness` rows are called out as mislabels.
+122 failures collapse into nine groups. Counts are from the reported
+`run.json` after the two report-time passes described in §1.4.
 
-| operation | failures | recorded layer | where | what actually happened |
+| operation | failures | layer | where | what actually happened |
 |---|---|---|---|---|
-| `glob.seed` | 60 | tool-helper | host-b, host-c, host-d (20/20 each) | `remote.glob` returned `remote python failed` on every Python 3.9.9 host. host-a (3.13) and all four containers (3.12) were 20/20. Deterministic on that interpreter, so the aggregate `flaky` hides a per-kind `broken`. |
-| `env.hostname_mapping` | 14 | environment | host-b-ctr 5/5, host-c-ctr 5/5, host-d-ctr 4/5 | `getent hosts $(hostname)` exited 3. Matches `gloo-init-container-hostname-missing-from-etc-hosts`. host-a-ctr was 5/5 (already mapped). |
-| `read.seed` | 20 | timeout | host-d 20/20 | Every call sat out the 30 s budget after `multi_session.*` on the same endpoint. |
-| `ls.seed` | 6 | timeout | host-d attempts 0–5 | Same hang; attempts 6–19 then passed. |
-| `multi_session.read` | 5 | timeout | host-d 5/5 | Four CLI processes sharing the ControlMaster; worker-0 hit the 30 s budget every time. |
-| `multi_session.bash` | 2 | timeout | host-d attempts 3–4 | Same mux, later repetitions. |
-| `artifact.interrupted_pull_transport` | 6 | integrity 5 + **harness 1** | integrity on host-a, host-c, host-d, host-d-ctr; harness on host-b attempt 3 | After SIGKILL of the wrapper's `ssh` child, five trials had a parsable payload whose outcome was not `failed`/`timeout` (`partial_state`). host-b attempt 3: in-process `remote.artifact_pull` **raised** `TimeoutExpired` on the ssh/ControlMaster argv at `rerun-pull` (214 s). Recorded as `harness`; correct layer is `transport`. |
-| `artifact.interrupted_pull_wrapper` | 3 | **harness 1** + timeout 2 | host-c only | Attempt 1: same leaked `TimeoutExpired` at `rerun-pull` (216 s), recorded `harness`, correct layer `transport`. Attempts 2–3 then timed out at `seed-remote` against the 180 s budget (trial wall ~392 s). Killing the connection wedged the mux; later commands on that endpoint hung for the full timeout. |
-| `artifact.interrupted_push_wrapper` | 4 | timeout 2 + integrity 2 | host-b 0/4 | Attempts 0–1 timed out inspecting remote leftovers (30 s budget; trial wall 422 s / 392 s). Attempts 2–3 left `*.tmp-*` files (`leftover_temp_files`). |
-| `artifact.interrupted_push_transport` | 2 | integrity | host-a-ctr, host-c | Wrapper payload after the transport drop was not a clean `failed`/`timeout`. |
+| `glob.seed` | 60 | tool-helper | host-b, host-c, host-d (20/20 each) | `remote.glob` returned `remote python failed` with an empty tail on every Python 3.9.9 host. host-a (3.13) and all four containers (3.12) were 20/20. Every repetition failed on every affected endpoint and none elsewhere: deterministic per interpreter, so the aggregate `flaky` hides a per-kind `broken`. |
+| `env.hostname_mapping` | 14 | environment | host-b-ctr 5/5, host-c-ctr 5/5, host-d-ctr 4/5 | `getent hosts $(hostname)` exited 3 and printed `UNMAPPED <hostname>`. Matches the promoted `gloo-init-container-hostname-missing-from-etc-hosts`. host-a-ctr was 5/5 (already mapped). The failing calls took ~11 s (p95 7.4 s): the container's hostname is a public-looking DNS name, so `getent` waits on a resolver before giving up. The one host-d-ctr pass is a genuine flake on the same container. |
+| host-d stall (`multi_session.bash` 2, `multi_session.read` 5, `read.seed` 20, `ls.seed` 6) | 33 | transport-stall | host-d only, 10:07:31Z–10:23:31Z | 33 consecutive trials, four unrelated operations, every one timing out at exactly its 30 s budget with an empty result. First failing trial: `multi_session.bash` attempt 3, all four separate CLI processes hung at once, seconds after `stream.under_load` finished on that endpoint. Attempts 0–2 of the same operation had passed. At 10:24:23Z `glob.seed` ran in 111 ms; nothing was restarted. Per-command error text was `remote python timed out after 30000 ms`, which blames the remote host. |
+| `artifact.interrupted_pull_transport` | 6 | integrity 5, transport 1 | integrity on host-a, host-c, host-d ×2, host-d-ctr; transport on host-b attempt 3 | After SIGKILL of the wrapper's `ssh` child, five trials had a payload with `outcome=success` (`partial_state`): the wrapper reported success after its own connection was killed. host-b attempt 3: in-process `remote.artifact_pull` **raised** `TimeoutExpired` on the ssh/ControlMaster argv at `rerun-pull` (214 s) instead of returning a payload; `verify-final-hashes` then saw 18 local / 0 remote / 32 expected and `cleanup` timed out. |
+| `artifact.interrupted_pull_wrapper` | 3 | transport 1, timeout 2 | host-c only | Attempt 1: same leaked `TimeoutExpired` at `rerun-pull` (216 s), 28 local / 0 remote / 32 expected afterwards. Attempts 2–3 then timed out at `seed-remote` against the 180 s budget (trial wall ~392 s): killing the connection wedged the mux and the next commands on that endpoint hung for their full timeout. |
+| `artifact.interrupted_push_wrapper` | 4 | timeout 2, integrity 2 | host-b 0/4 | Attempts 0–1 timed out inspecting remote leftovers (30 s budget; trial wall 422 s / 392 s). Attempts 2–3 left one `*.tmp-*` file each (`leftover_temp_files`). |
+| `artifact.interrupted_push_transport` | 2 | integrity | host-a-ctr, host-c | Wrapper payload after the transport drop was `outcome=success` (`partial_state`). |
 
-host-d's timeout cascade (`multi_session` → `read.seed` 20/20 → `ls.seed`
-6, then writes recovered) started **before** the interrupted-transfer
-ops. The shared mux can stall under four concurrent CLI processes, not
-only after an explicit `ssh` child kill. The kill path is worse: it
-leaves the mux wedged so the *next* in-process `artifact_pull` never
-returns a result.
+Two things about the stall. First, it started **before** any
+interrupted-transfer operation ran on host-d; the trigger was four fresh
+CLI processes racing `ControlMaster=auto` on the same socket right after
+a 12 s stream. Second, nothing recovered it — it ended by itself after
+16 minutes. The kill path (`interrupted_*`) produces the same symptom on
+host-b and host-c for a few trials each, and adds a worse one: the next
+in-process `artifact_pull` leaks `TimeoutExpired` instead of returning.
 
-That kill-the-master shape belongs to the same family as
+Both belong to the same family as
 `ssh-stream-over-shared-controlmaster-mux-dies-early`. The recorded
-signature is long streams dying early; this pass shows the complementary
-failure: a dead or recycled ControlMaster master, then every later
-command on that endpoint burns its full timeout.
+signature is a long stream dying early; this pass shows the complementary
+failure: a dead or wedged master behind a live socket, then every later
+command on that endpoint burns its full budget and is reported as a
+remote timeout.
 
-`--capture-knowledge` was not passed. The harness still prepared 11
-redacted candidates (reproduced ≥ 2 times) under untracked evidence.
-They were not handed to `knowledge_capture.py`.
+Eight redacted candidates (each reproduced ≥ 2 times) were handed to
+`.agents/scripts/knowledge_capture.py` with `--capture-knowledge` on the
+replay; all eight passed its validation and were created under untracked
+`.vaws-local/knowledge/candidates/` (owner skill `remote-toolbox`). The
+stall and the `glob.seed` interpreter mismatch are `medium` confidence
+(one is an endpoint-wide episode, the other deterministic per
+environment); the rest are `low`. Nothing under `.agents/knowledge/` was
+edited; promotion is a `curate-workspace-knowledge` decision.
 
 ## 3. Least mature mechanics, ranked
 
 Harness ranking (broken / flaky by pass rate, then slow). Interpretation
 is ours; the rates are from `pass-1`.
 
-1. **`remote.glob` helper on Python 3.9.9 hosts** — 62.5 % overall,
-   0/60 on the three 3.9.9 hosts, 100/100 elsewhere. `tool-helper`.
-   Lowest rate in the pass, but a deterministic interpreter/helper
-   mismatch, not a race. Blocks the `search` class until the helper
-   either works on 3.9 or the tool fails closed with a typed error.
-2. **Container hostname mapping** — 65.0 %. Already a promoted
-   signature. Three of four containers are `broken` or nearly so. The
-   other environment ops (`probe`, `context_snapshot`) were mature.
-3. **Interrupted transfer over the shared ControlMaster** — all four
-   recovery ops flaky (81–94 %). This is the finding that matters for
-   consolidation. Killing the wrapper's `ssh` child when that child is
-   (or becomes) the ControlMaster master wedges the mux; the next
-   `artifact_pull` either leaks `TimeoutExpired` or the next `remote.bash`
-   sits out its whole budget. Uninterrupted push/pull (256 KiB and
-   8 MiB) were 120/120, so the bytes-and-hash path is fine — the
-   *interrupt* path is not.
-4. **Multi-session mux contention, then poisoned file ops** — host-d
-   only. `multi_session.read` 0/5, `multi_session.bash` 3/5,
-   `read.seed` 0/20, `ls.seed` 14/20. Same layer (`timeout`), same
-   endpoint, then writes/patches/jobs recovered. In-process
-   `bash.concurrent` (6 workers) was 40/40 everywhere, so the in-process
-   dispatcher is not the problem; four separate CLI processes sharing
-   the mux are.
+1. **The shared ControlMaster channel under concurrent sessions and
+   interrupted connections.** Two shapes, one mechanism:
+   - *Stall without a kill* — host-d, 33 consecutive trials, 16 minutes,
+     four unrelated operations, every command timing out at its full
+     budget and reported as `remote python timed out`. Triggered by four
+     separate CLI processes racing `ControlMaster=auto` right after a
+     stream; recovered by itself. `multi_session.read` 35/40,
+     `multi_session.bash` 38/40, `read.seed` 140/160, `ls.seed` 154/160
+     are all this one episode.
+   - *Stall after a kill* — the four `recovery` ops, 81–94 %. Killing the
+     wrapper's `ssh` child mid-transfer wedges the mux for the next
+     commands (2 + 2 full-budget timeouts on host-b and host-c) and the
+     next in-process `artifact_pull` leaks `TimeoutExpired` instead of
+     returning (2 trials, 214 s and 216 s). Uninterrupted push/pull
+     (256 KiB and 8 MiB) were 120/120, so bytes-and-hash is fine; the
+     interrupt path is not.
+   In-process `bash.concurrent` (6 workers) was 40/40 everywhere, so the
+   dispatcher is not the problem; separate processes sharing one socket
+   are.
+2. **Interrupted-transfer reporting** — 7 of the 15 `recovery` failures
+   are `integrity`: after its own connection was SIGKILLed, the wrapper
+   returned `outcome=success` (5 trials) or left a `*.tmp-*` file on the
+   remote (2 trials). Independent of the mux: a killed transfer must
+   fail closed and clean up.
+3. **`remote.glob` helper on Python 3.9.9 hosts** — 62.5 % overall,
+   0/60 on the three 3.9.9 hosts, 100/100 elsewhere. `tool-helper`,
+   empty error tail. Lowest rate in the pass, but a deterministic
+   interpreter/helper mismatch, not a race. Blocks the `search` class
+   until the helper works on 3.9 or fails closed with a typed error.
+4. **Container hostname mapping** — 65.0 %. Already a promoted
+   signature. Three of four containers `broken` or nearly so, with an
+   ~11 s resolver wait on each failing call. `probe` and
+   `context_snapshot` were mature.
 5. **`edit.rerun_contract` latency on host-a** — 80/80 correct, p95
    4635 ms against a 4000 ms class budget, driven by host-a (Python
    3.13). A `slow` verdict, not a functional one.
@@ -311,11 +348,13 @@ real-timeout contract and 200 kB output, long streams alone and under
 load, `grep`, patch add/rerun and update+move, job start/poll/tail/stop,
 artifact hash round-trips — held `mature` on all eight endpoints.
 
-**Least trusted mechanic today:** interrupting a transfer by killing
-the `ssh` child on a shared ControlMaster (the `recovery` class). A
-single such kill can take the endpoint's mux down for every later
-command. `remote.glob` on 3.9.9 is a close second but it fails the same
-way every time and does not poison neighbours.
+**Least trusted mechanic today:** the shared SSH ControlMaster channel
+when more than one process uses it or a connection through it is
+killed. It is the only fault in this pass that spreads: one stall took
+an otherwise healthy endpoint out for every command for 16 minutes,
+and the per-command error blamed the remote host. `remote.glob` on
+3.9.9 has a lower rate but fails the same way every time and does not
+poison neighbours.
 
 ## 4. Deliberately left undone
 
@@ -332,16 +371,20 @@ way every time and does not poison neighbours.
   independent runs; the numbers above are a first data point, not a verdict.
 - Latency budgets are fixed per class and not yet normalised for the slow
   interpreter start-up on one host; that host is reported, not excluded.
-- The two leaked `TimeoutExpired` rows stay labelled `harness` in the
-  retained `run.json`. Attribution was fixed for future runs; the evidence
-  was not rewritten and no second hardware pass was started.
-- Reproducible failures were prepared as redacted candidates but not
-  captured (`--capture-knowledge` was off). Knowledge files were not
-  edited.
 - Isolated interruption of a transfer CLI child now opts that one
   process out of the shared mux (`REMOTE_DEV_SSH_MUX=0` on the copied
   child environment only). The provider package that turns that variable
   into `ControlMaster=no` / `ControlPath=none` / `ControlPersist=no` is
   a pending root-owned integration; local consumer tests do not treat
-  the embedded provider as that candidate. No second hardware pass was
-  run, and ordinary timeout/cancellation paths were not redesigned.
+  the embedded provider as that candidate. Ordinary timeout/cancellation
+  paths were not redesigned.
+- The stall detector is a report-time heuristic (≥ 3 consecutive
+  full-budget timeouts on one endpoint). It names the pattern; it does not
+  prove the ControlMaster cause. Confirming that needs the mux socket's
+  state captured at stall start, which the harness does not collect yet.
+- No second hardware pass was started after the attribution or mux-opt-out
+  changes. The `pass-1` figures above come from replaying retained evidence
+  through the current report code; the trial records themselves are
+  unchanged.
+- Candidates were captured, not promoted. Nothing under `.agents/knowledge/`
+  was edited.


### PR DESCRIPTION
Follow-up to #93. The harness and the `pass-1` hardware pass landed there with the run-time attribution. Reading the retained evidence afterwards showed two labelling problems that changed the ranking; this PR fixes the attribution rules, replays `pass-1` through them, captures the reproducible failures as knowledge candidates, and updates `docs/deterministic-core-maturation.md` with the reattributed figures. No existing script's behaviour changes; no new hardware pass was run.

## What the evidence showed

`pass-1`: 8 endpoints (4 hosts + 4 containers), 31 operations, **2216 trials, 2094 passes, 122 failures (94.5 %)**, 2322 s wall, no endpoint skipped.

Run-time layers: `tool-helper` 60, `timeout` 37, `environment` 14, `integrity` 9, `harness` 2.

1. **33 of the 37 "timeouts" were one episode.** On `host-d`, from 10:07:31Z to 10:23:31Z, 33 consecutive trials across four unrelated operations (`multi_session.bash`, `multi_session.read`, `read.seed`, `ls.seed`) each timed out at exactly its 30 s budget with an empty result, then at 10:24:23Z `glob.seed` ran in 111 ms with nothing restarted. The first failing trial was four separate CLI processes racing `ControlMaster=auto` on one socket seconds after a 12 s stream; attempts 0–2 of the same operation had passed. The per-command error was `remote python timed out after 30000 ms`, which blames the remote host. Reporting these per operation made `read.seed` (140/160) and `ls.seed` (154/160) look flaky when both were 100 % outside the episode.
2. **The two `harness` rows were transport.** In-process `remote.artifact_pull` raised `TimeoutExpired` on the ssh/ControlMaster argv (214 s, 216 s) instead of returning a payload, after the wrapper's `ssh` child had been SIGKILLed. The rule mapping that to `transport` existed but post-dated the run.

## Changes

- `attribution.py`: `reclassify_endpoint_stalls` — ≥ 3 consecutive trials on one endpoint, all timing out at ≥ 95 % of budget, across any operations → new layer `transport-stall`, one episode record each. `refresh_exception_attribution` — retained `harness`-layer exceptions re-run through the current exception rules. Both keep `original_layer`.
- `runner.py`: both passes run in `finalize`, so a live run and `--report <run-id>` replays agree; episodes land in `summary.stall_episodes` and a new "Endpoint stalls" section of `summary.md`; replay keeps the original `finished_at` and records `reported_at`; stale candidate files from an earlier attribution pass are pruned.
- `knowledge.py`: stall trials group into one candidate (`ssh-transport`, `medium`) regardless of operation, with the recorded ControlMaster signature as the working hypothesis. Groups where every repetition failed on each affected endpoint and none elsewhere are marked "deterministic per environment" (`medium`) instead of "flake".
- `scenarios.py`: step records now carry `timeout_ms` so the stall ratio is computed from data, not assumed.
- `evidence.py`: `prune_candidates`.
- Tests: stall detection (threshold, budget ratio, isolated timeouts untouched), exception refresh, stall grouping, per-environment determinism. Fixtures use RFC 5737 addresses. `python3 -m compileall .agents` clean; full `.agents/tests` suite OK (skips are the external-provider tests without `VAWS_REMOTE_DEV_ROOT`); `tracked_leak_scan.py --commit-range origin/main..HEAD`: 0 findings.

## Reattributed results

Layers: `tool-helper` 60, `transport-stall` 33, `environment` 14, `integrity` 9, `timeout` 4, `transport` 2.

| class | n | pass | rate | failure layers |
|---|---|---|---|---|
| transport | 480 | 480 | 100.0 % | — |
| stream | 72 | 72 | 100.0 % | — |
| transfer | 120 | 120 | 100.0 % | — |
| patch | 160 | 160 | 100.0 % | — |
| jobs | 96 | 96 | 100.0 % | — |
| file_ops | 560 | 534 | 95.4 % | transport-stall 26 (all host-d episode) |
| concurrency | 120 | 113 | 94.2 % | transport-stall 7 (all host-d episode) |
| environment | 160 | 146 | 91.3 % | environment 14 |
| recovery | 128 | 113 | 88.3 % | integrity 9, timeout 4, transport 2 |
| search | 320 | 260 | 81.3 % | tool-helper 60 |

Every failure, attributed:

| group | n | layer | where | what happened |
|---|---|---|---|---|
| `glob.seed` | 60 | tool-helper | host-b, host-c, host-d — 20/20 each | `remote.glob` → `remote python failed`, empty tail, on every Python 3.9.9 host; 100/100 on 3.12/3.13. Deterministic per interpreter; aggregate "62.5 % flaky" hides a per-kind `broken`. |
| `env.hostname_mapping` | 14 | environment | host-b-ctr 5/5, host-c-ctr 5/5, host-d-ctr 4/5 | `getent hosts $(hostname)` exit 3, ~11 s resolver wait. Matches promoted `gloo-init-container-hostname-missing-from-etc-hosts`. |
| host-d stall | 33 | transport-stall | host-d, 10:07:31Z–10:23:31Z | Above. |
| `artifact.interrupted_pull_transport` | 6 | integrity 5, transport 1 | host-a, host-c, host-d ×2, host-d-ctr; host-b | Wrapper returned `outcome=success` after its own ssh child was SIGKILLed (`partial_state`); one leaked `TimeoutExpired` at `rerun-pull` (214 s). |
| `artifact.interrupted_pull_wrapper` | 3 | transport 1, timeout 2 | host-c | Leaked `TimeoutExpired` (216 s), then two 180 s `seed-remote` timeouts on the wedged mux. |
| `artifact.interrupted_push_wrapper` | 4 | timeout 2, integrity 2 | host-b 0/4 | Two 30 s timeouts inspecting leftovers; two `*.tmp-*` files left behind. |
| `artifact.interrupted_push_transport` | 2 | integrity | host-a-ctr, host-c | `outcome=success` after transport drop. |

## Knowledge feedback

`--capture-knowledge` on the replay handed 8 redacted candidates to `.agents/scripts/knowledge_capture.py`; all 8 passed validation and were created under untracked `.vaws-local/knowledge/candidates/` (owner `remote-toolbox`). `medium`: the endpoint-wide stall and the `glob.seed` interpreter mismatch. `low`: hostname mapping (one genuine pass on host-d-ctr) and the five interrupted-transfer groups. Nothing under `.agents/knowledge/` was edited; promotion is a `curate-workspace-knowledge` decision.

## Least mature, ranked

1. **Shared ControlMaster channel under concurrent sessions or a killed connection** — the only fault that spreads: one stall took a healthy endpoint out for every command for 16 minutes and the error blamed the remote host. Least trusted mechanic today.
2. **Interrupted-transfer reporting** — 7/15 recovery failures are the wrapper reporting success or leaving temp files after its connection was killed. Must fail closed.
3. **`remote.glob` on Python 3.9.9** — 0/60 there, 100/100 elsewhere; lowest rate but deterministic and does not poison neighbours.
4. **Container hostname mapping** — 65 %, already promoted.
5. **`edit.rerun_contract` p95 4635 ms vs 4000 ms budget** — correctness 80/80; host-a interpreter start-up.

## Left undone

- The stall detector names the pattern; it does not prove the ControlMaster cause. That needs the mux socket state captured at stall start, which the harness does not collect yet.
- No second hardware pass after the attribution or mux-opt-out changes; figures are a replay of unchanged trial records.
