### PR TITLE
Consume separate knowledge and experience stores

### DIFF
--- a/.agents/lib/vaws_knowledge_service.py
+++ b/.agents/lib/vaws_knowledge_service.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
 
 PROJECT_ROOT_RELATIVE = ".agents/knowledge"
 CANDIDATE_ROOT_RELATIVE = ".vaws-local/knowledge/candidate"
+EXPERIENCE_PROJECT_ROOT_RELATIVE = ".agents/experiences"
+EXPERIENCE_CANDIDATE_ROOT_RELATIVE = ".vaws-local/experience/candidate"
 
 
 def origin_repo_from_url(url: str) -> str:
@@ -62,6 +64,8 @@ def knowledge_server_env(repo_root: Path) -> dict[str, str]:
     else:
         result["VAWS_KNOWLEDGE_PROJECT_ROOTS"] = str(repo_root / PROJECT_ROOT_RELATIVE)
         result["VAWS_KNOWLEDGE_CANDIDATE_ROOT"] = str(repo_root / CANDIDATE_ROOT_RELATIVE)
+        result["VAWS_EXPERIENCE_PROJECT_ROOTS"] = str(repo_root / EXPERIENCE_PROJECT_ROOT_RELATIVE)
+        result["VAWS_EXPERIENCE_CANDIDATE_ROOT"] = str(repo_root / EXPERIENCE_CANDIDATE_ROOT_RELATIVE)
         result["VAWS_KNOWLEDGE_STATE"] = str(repo_root / ".vaws-local/knowledge/instance")
     return result
 
@@ -80,7 +84,8 @@ def knowledge_owner_env(repo_root: Path) -> dict[str, str]:
     environment["VAWS_ENV_RECEIPT"] = managed_receipt(repo_root)["receipt"]
     if windows_mounted_workspace(repo_root):
         for key in ("VAWS_KNOWLEDGE_CONFIG", "VAWS_KNOWLEDGE_PROJECT_ROOTS",
-                    "VAWS_KNOWLEDGE_CANDIDATE_ROOT", "VAWS_KNOWLEDGE_STATE"):
+                    "VAWS_KNOWLEDGE_CANDIDATE_ROOT", "VAWS_KNOWLEDGE_STATE",
+                    "VAWS_EXPERIENCE_PROJECT_ROOTS", "VAWS_EXPERIENCE_CANDIDATE_ROOT"):
             if key in environment:
                 environment[key] = knowledge_owner_path(repo_root, environment[key])
         if os.environ.get("WSLENV"):
@@ -126,6 +131,7 @@ def service_config(
     *,
     project_root: Path | None = None,
     candidate_root: Path | None = None,
+    kind: str = "knowledge",
 ) -> ServiceConfig:
     from vaws_knowledge.server.layers import load_config
 
@@ -140,27 +146,44 @@ def service_config(
                 "candidate": {"root": str(repo_root / CANDIDATE_ROOT_RELATIVE)},
             },
             "identity": knowledge_identity(repo_root),
+            "experience": {"layers": {
+                "project": {"roots": [str(repo_root / EXPERIENCE_PROJECT_ROOT_RELATIVE)]},
+                "candidate": {"root": str(repo_root / EXPERIENCE_CANDIDATE_ROOT_RELATIVE)},
+            }},
         }
     if os.environ.get("VAWS_KNOWLEDGE_BACKEND"):
         mapping["backend"] = os.environ["VAWS_KNOWLEDGE_BACKEND"]
-    if project_root is not None:
-        mapping.setdefault("layers", {})["project"] = {"roots": [str(project_root)]}
-    if candidate_root is not None:
-        mapping.setdefault("layers", {})["candidate"] = {"root": str(candidate_root)}
+    if kind not in {"knowledge", "experience"}:
+        raise ValueError(f"unknown reference kind: {kind}")
+    if project_root is not None or candidate_root is not None:
+        selected = mapping if kind == "knowledge" else mapping.setdefault("experience", {})
+        if project_root is not None:
+            selected.setdefault("layers", {})["project"] = {"roots": [str(project_root)]}
+        if candidate_root is not None:
+            selected.setdefault("layers", {})["candidate"] = {"root": str(candidate_root)}
     return load_config(
         mapping,
         env={},
         path=config_path if config_path.is_file() else None,
         base_dir=repo_root,
-    )
+    ).for_kind(kind)
 
 
 def query_knowledge(*, knowledge_dir: Path, query: str, limit: int = 3) -> dict[str, Any]:
     """Keep index availability distinct from a successful query with zero results."""
-    repo = knowledge_dir.parent.parent if knowledge_dir.parent.name == ".agents" else knowledge_dir.parent
+    return _query_references(directory=knowledge_dir, query=query, limit=limit, kind="knowledge")
+
+
+def query_experience(*, experience_dir: Path, query: str, limit: int = 3) -> dict[str, Any]:
+    """Look up historical cases separately from current knowledge."""
+    return _query_references(directory=experience_dir, query=query, limit=limit, kind="experience")
+
+
+def _query_references(*, directory: Path, query: str, limit: int, kind: str) -> dict[str, Any]:
+    repo = directory.parent.parent if directory.parent.name == ".agents" else directory.parent
     try:
         from vaws_knowledge.server.query import query as package_query
-        result = package_query(service_config(repo, project_root=knowledge_dir), text=query, limit=limit)
+        result = package_query(service_config(repo, project_root=directory, kind=kind), text=query, limit=limit)
         return result.to_dict()
     except Exception as exc:
-        return {"results": [], "unavailable": True, "degraded": True, "index_detail": str(exc)}
+        return {"kind": kind, "results": [], "unavailable": True, "degraded": True, "index_detail": str(exc)}

--- a/.agents/scripts/vaws_client_setup.py
+++ b/.agents/scripts/vaws_client_setup.py
@@ -13,7 +13,8 @@ Three logical providers are written when needed:
   attach/finish need no manager.
 * `remote-dev` -> `python -m remote_dev.mcp.server`, which serves `remote_*`.
 * `vaws-knowledge` -> `python -m vaws_knowledge.server.mcp_server`, which
-  serves `knowledge_query` / `knowledge_explain` / `knowledge_capture`.
+  serves `knowledge_query` / `knowledge_explain` / `knowledge_capture` and
+  `experience_query` / `experience_explain` / `experience_capture`.
 
 `--task-only` writes only the vaws-task entry; it skips remote-dev and
 vaws-knowledge.
@@ -495,6 +496,8 @@ def knowledge_owner_defaults(existing, desired, checkout):
         if desired.get("env", {}).get("VAWS_KNOWLEDGE_CONFIG"):
             defaults = {"VAWS_KNOWLEDGE_PROJECT_ROOTS": ".agents/knowledge",
                         "VAWS_KNOWLEDGE_CANDIDATE_ROOT": ".vaws-local/knowledge/candidate",
+                        "VAWS_EXPERIENCE_PROJECT_ROOTS": ".agents/experiences",
+                        "VAWS_EXPERIENCE_CANDIDATE_ROOT": ".vaws-local/experience/candidate",
                         "VAWS_KNOWLEDGE_STATE": ".vaws-local/knowledge/instance"}
             for key, relative in defaults.items():
                 if key in environment and key not in desired.get("env", {}) and (
@@ -502,7 +505,8 @@ def knowledge_owner_defaults(existing, desired, checkout):
                 ):
                     environment.pop(key)
         for key in ("VAWS_KNOWLEDGE_CONFIG", "VAWS_KNOWLEDGE_PROJECT_ROOTS",
-                    "VAWS_KNOWLEDGE_CANDIDATE_ROOT", "VAWS_KNOWLEDGE_STATE"):
+                    "VAWS_KNOWLEDGE_CANDIDATE_ROOT", "VAWS_KNOWLEDGE_STATE",
+                    "VAWS_EXPERIENCE_PROJECT_ROOTS", "VAWS_EXPERIENCE_CANDIDATE_ROOT"):
             value = desired.get("env", {}).get(key)
             if key in environment and value is not None and (
                 server_command_identity(environment[key], checkout) == server_command_identity(value, checkout)

--- a/.agents/scripts/vaws_client_setup.py
+++ b/.agents/scripts/vaws_client_setup.py
@@ -14,7 +14,7 @@ Three logical providers are written when needed:
 * `remote-dev` -> `python -m remote_dev.mcp.server`, which serves `remote_*`.
 * `vaws-knowledge` -> `python -m vaws_knowledge.server.mcp_server`, which
   serves `knowledge_query` / `knowledge_explain` / `knowledge_capture` and
-  `experience_query` / `experience_explain` / `experience_capture`.
+  `experience_query` / `experience_explain` / `experience_capture` / `experience_feedback`.
 
 `--task-only` writes only the vaws-task entry; it skips remote-dev and
 vaws-knowledge.

--- a/.agents/tests/test_knowledge_client_setup.py
+++ b/.agents/tests/test_knowledge_client_setup.py
@@ -137,6 +137,8 @@ def test_service_config_replaces_only_generated_default_root_environment(format,
         "env": {
             "VAWS_KNOWLEDGE_PROJECT_ROOTS": ".agents/knowledge",
             "VAWS_KNOWLEDGE_CANDIDATE_ROOT": "/custom/candidate" if custom_candidate else str(tmp_path / ".vaws-local/knowledge/candidate"),
+            "VAWS_EXPERIENCE_PROJECT_ROOTS": ".agents/experiences",
+            "VAWS_EXPERIENCE_CANDIDATE_ROOT": "/custom/experience" if custom_candidate else str(tmp_path / ".vaws-local/experience/candidate"),
             "VAWS_KNOWLEDGE_STATE": str(tmp_path / ".vaws-local/knowledge/instance"),
             "CUSTOM": "keep",
         },
@@ -155,7 +157,10 @@ def test_service_config_replaces_only_generated_default_root_environment(format,
     assert environment["VAWS_KNOWLEDGE_CONFIG"] == desired["env"]["VAWS_KNOWLEDGE_CONFIG"]
     assert "VAWS_KNOWLEDGE_PROJECT_ROOTS" not in environment
     assert "VAWS_KNOWLEDGE_STATE" not in environment
+    assert "VAWS_EXPERIENCE_PROJECT_ROOTS" not in environment
+    assert ("VAWS_EXPERIENCE_CANDIDATE_ROOT" in environment) is custom_candidate
     assert ("VAWS_KNOWLEDGE_CANDIDATE_ROOT" in environment) is custom_candidate
     if custom_candidate:
         assert environment["VAWS_KNOWLEDGE_CANDIDATE_ROOT"] == "/custom/candidate"
+        assert environment["VAWS_EXPERIENCE_CANDIDATE_ROOT"] == "/custom/experience"
     assert environment["CUSTOM"] == "keep"

--- a/.agents/tests/test_knowledge_flow.py
+++ b/.agents/tests/test_knowledge_flow.py
@@ -7,7 +7,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from vaws_knowledge_service import knowledge_server_env, query_knowledge, service_config
+from vaws_knowledge_service import knowledge_server_env, query_experience, query_knowledge, service_config
 from vaws_knowledge.markdown import load_document
 from vaws_knowledge.local.instance import instance_for_config
 from vaws_knowledge.server.capture import capture
@@ -110,6 +110,84 @@ class KnowledgeFlowTests(unittest.TestCase):
             hook = service_config(root)
             self.assertEqual(instance_for_config(mcp).state_root, root / ".vaws-local/knowledge/instance")
             self.assertEqual(instance_for_config(mcp).state_root, instance_for_config(hook).state_root)
+            for config in (mcp, hook):
+                experience = config.for_kind("experience")
+                self.assertEqual(experience.mount("project").roots, (root / ".agents/experiences",))
+                self.assertEqual(experience.mount("candidate").roots, (root / ".vaws-local/experience/candidate",))
+                self.assertEqual(instance_for_config(experience).state_root, instance_for_config(config).state_root)
+
+    def test_explicit_experience_mounts_are_shared_by_mcp_hook_and_prepare(self):
+        from vaws_knowledge.maintenance import project_config
+        from vaws_knowledge.summary_hook import capture_summary
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary).resolve()
+            path = root / ".vaws-local/knowledge/service.json"
+            path.parent.mkdir(parents=True)
+            project, candidate = root / "custom-project", root / "custom-experiences"
+            path.write_text(json.dumps({"backend": "memory", "experience": {"layers": {
+                "project": {"roots": [str(project)]}, "candidate": {"root": str(candidate)}}},
+                "publishing": {"enabled": False}}), encoding="utf-8")
+            prepared = project_config(root)
+            for config in (prepared, load_config(env=knowledge_server_env(root)), service_config(root)):
+                experience = config.for_kind("experience")
+                self.assertEqual(experience.mount("project").roots, (project,))
+                self.assertEqual(experience.mount("candidate").roots, (candidate,))
+            saved = capture_summary({"hook_event_name": "Stop", "last_assistant_message":
+                "The original workaround helped this run, although the cause remains uncertain."},
+                config=service_config(root), client="codex")
+            self.assertEqual(saved["kind"], "experience")
+            self.assertEqual(len(list(candidate.glob("*.md"))), 1)
+            self.assertFalse((root / ".vaws-local/knowledge/candidate").exists())
+
+    def test_prepare_supplies_both_default_roots_without_reclassifying_old_notes(self):
+        from vaws_knowledge.maintenance import project_config
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary).resolve()
+            old = root / ".agents/knowledge/old.md"
+            old.parent.mkdir(parents=True)
+            old.write_text("# Older note\n\nHistorical observation awaiting review.\n", encoding="utf-8")
+            config = project_config(root)
+            self.assertEqual(config.for_kind("experience").mount("project").roots, (root / ".agents/experiences",))
+            self.assertEqual(config.for_kind("experience").mount("candidate").roots, (root / ".vaws-local/experience/candidate",))
+            self.assertTrue(old.is_file())
+            self.assertFalse((root / ".agents/experiences/old.md").exists())
+
+    def test_optional_experience_lookup_selects_only_experience(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary) / ".agents/experiences"
+            with mock.patch("vaws_knowledge.server.query.query") as query:
+                query.return_value.to_dict.return_value = {"kind": "experience", "results": []}
+                result = query_experience(experience_dir=directory, query="old workaround")
+            config = query.call_args.args[0]
+            self.assertEqual(config.kind, "experience")
+            self.assertEqual(config.mount("project").roots, (directory,))
+            self.assertEqual(result["kind"], "experience")
+
+    def test_existing_experience_config_retains_all_roots_with_a_project_override(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary).resolve()
+            path = root / ".vaws-local/knowledge/service.json"
+            path.parent.mkdir(parents=True)
+            roots = {layer: root / "custom-experience" / layer for layer in ("shared", "project", "candidate")}
+            for directory in roots.values():
+                directory.mkdir(parents=True)
+            payload = {"backend": "memory", "experience": {"layers": {
+                layer: {"roots": [str(directory)]} for layer, directory in roots.items()}}}
+            path.write_text(json.dumps(payload), encoding="utf-8")
+
+            configured = service_config(root, kind="experience")
+            for layer, directory in roots.items():
+                self.assertEqual(configured.mount(layer).roots, (directory,))
+
+            replacement = root / "replacement-project"
+            replacement.mkdir()
+            overridden = service_config(root, kind="experience", project_root=replacement)
+            self.assertEqual(overridden.mount("project").roots, (replacement,))
+            for layer in ("candidate", "shared"):
+                self.assertEqual(overridden.mount(layer).roots, (roots[layer],))
+            self.assertEqual(json.loads(path.read_text(encoding="utf-8")), payload)
 
     def test_historical_observation_retains_its_source_and_limits(self):
         root = ROOT / ".agents/knowledge"

--- a/.agents/tests/test_knowledge_mcp_server.py
+++ b/.agents/tests/test_knowledge_mcp_server.py
@@ -14,7 +14,7 @@ sys.path.insert(0, str(ROOT / ".agents" / "lib"))
 from vaws_knowledge_service import knowledge_server_env  # noqa: E402
 
 TOOLS = {"knowledge_query", "knowledge_explain", "knowledge_capture",
-         "experience_query", "experience_explain", "experience_capture"}
+         "experience_query", "experience_explain", "experience_capture", "experience_feedback"}
 
 
 def _rpc(method: str, request_id: int, params: dict | None = None) -> dict:

--- a/.agents/tests/test_knowledge_mcp_server.py
+++ b/.agents/tests/test_knowledge_mcp_server.py
@@ -13,7 +13,8 @@ sys.path.insert(0, str(ROOT / ".agents" / "lib"))
 
 from vaws_knowledge_service import knowledge_server_env  # noqa: E402
 
-TOOLS = {"knowledge_query", "knowledge_explain", "knowledge_capture"}
+TOOLS = {"knowledge_query", "knowledge_explain", "knowledge_capture",
+         "experience_query", "experience_explain", "experience_capture"}
 
 
 def _rpc(method: str, request_id: int, params: dict | None = None) -> dict:
@@ -36,7 +37,7 @@ def _read_response(proc: subprocess.Popen[bytes]) -> dict:
 
 
 class KnowledgeMcpHandshakeTest(unittest.TestCase):
-    def test_initialize_lists_the_three_tools(self) -> None:
+    def test_initialize_lists_both_stores_tools(self) -> None:
         env = {
             **dict(__import__("os").environ),
             **knowledge_server_env(ROOT),

--- a/.agents/tests/test_knowledge_prepare.py
+++ b/.agents/tests/test_knowledge_prepare.py
@@ -47,6 +47,8 @@ def test_windows_owner_receives_native_paths_and_explicit_environment(monkeypatc
         "VAWS_KNOWLEDGE_CONFIG": "/mnt/d/work/.vaws-local/knowledge/service.json",
         "VAWS_KNOWLEDGE_PROJECT_ROOTS": "/mnt/d/work/.agents/knowledge",
         "VAWS_KNOWLEDGE_CANDIDATE_ROOT": "/mnt/d/work/.vaws-local/knowledge/candidate",
+        "VAWS_EXPERIENCE_PROJECT_ROOTS": "/mnt/d/work/.agents/experiences",
+        "VAWS_EXPERIENCE_CANDIDATE_ROOT": "/mnt/d/work/.vaws-local/experience/candidate",
         "VAWS_KNOWLEDGE_STATE": "/mnt/d/work/.vaws-local/knowledge/instance",
         "VAWS_KNOWLEDGE_ORIGIN_REPO": "example/repo",
     })
@@ -55,6 +57,8 @@ def test_windows_owner_receives_native_paths_and_explicit_environment(monkeypatc
     assert environment["VAWS_KNOWLEDGE_PROJECT_ROOTS"] == r"D:\work\.agents\knowledge"
     assert environment["VAWS_KNOWLEDGE_CONFIG"] == r"D:\work\.vaws-local\knowledge\service.json"
     assert environment["VAWS_KNOWLEDGE_STATE"] == r"D:\work\.vaws-local\knowledge\instance"
+    assert environment["VAWS_EXPERIENCE_PROJECT_ROOTS"] == r"D:\work\.agents\experiences"
+    assert environment["VAWS_EXPERIENCE_CANDIDATE_ROOT"] == r"D:\work\.vaws-local\experience\candidate"
     assert environment["VAWS_KNOWLEDGE_ORIGIN_REPO"] == "example/repo"
     assert environment[envs.PIN_ENV] == receipt
     assert "CUSTOM/w" in environment["WSLENV"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,8 @@ remotes, not replacements for community upstreams.
 | Workspace initialization or client wiring | `.agents/skills/repo-init/SKILL.md` |
 | Start a native CLI in an independent editing directory | `.agents/scripts/vaws_client.py CLIENT` |
 | Local fleet monitor lifecycle | `.agents/skills/npu-fleet-monitor/SKILL.md`; observation is not allocation |
-| Knowledge lookup and capture | `knowledge_query`, `knowledge_explain`, `knowledge_capture` |
+| Current knowledge lookup and capture | `knowledge_query`, `knowledge_explain`, `knowledge_capture` |
+| Historical experience lookup and capture | `experience_query`, `experience_explain`, `experience_capture` |
 
 Bind default business worktrees with `vaws_session(sources=...)`, or pass
 `sources` to one `vaws_run`; an empty map runs without project sources.
@@ -61,6 +62,11 @@ conditions, evidence and uncertainty in the text without a schema. Configured
 hooks reuse the normal summary; manual capture can reuse useful existing text.
 No second summary or publishing follow-up is required. Storage and maintenance
 details are in the [knowledge contract](docs/target-state.md#54-knowledge).
+Knowledge and experience use separate stores and queries. Knowledge describes
+current conclusions and requires evidence against current code when updated.
+Experience preserves past actions, observations and outcomes; historical commands
+are clues to investigate, not current instructions. Summary hooks save experiences.
+Writing into either store does not certify a claim or promote historical content.
 For explicit knowledge maintenance, the optional package skill is available
 through its configured interpreter with `python -m vaws_knowledge skill`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ remotes, not replacements for community upstreams.
 | Local fleet monitor lifecycle | `.agents/skills/npu-fleet-monitor/SKILL.md`; observation is not allocation |
 | Current knowledge lookup and capture | `knowledge_query`, `knowledge_explain`, `knowledge_capture` |
 | Historical experience lookup and capture | `experience_query`, `experience_explain`, `experience_capture` |
+| Optional published-experience feedback | `experience_feedback(ref, vote)` with `+1` or `-1`; no reason required |
 
 Bind default business worktrees with `vaws_session(sources=...)`, or pass
 `sources` to one `vaws_run`; an empty map runs without project sources.

--- a/docs/target-state.md
+++ b/docs/target-state.md
@@ -156,7 +156,14 @@ responsible for the scope of a conclusion.
 ### 5.4 Knowledge
 
 Use `knowledge_query(text)`, `knowledge_explain(ref)` and `knowledge_capture(title, content)`
-when they help. A title and non-empty Markdown body suffice; no frontmatter,
+for current conclusions. Use `experience_query(text)`, `experience_explain(ref)`
+and `experience_capture(title, content)` for historical cases: what was done,
+observed and resolved under the original conditions. Knowledge requires updates
+when code or conditions change; experiences can preserve old implementations as
+historical context. Correct mistaken interpretations while retaining the observed
+evidence. Historical commands are investigation clues, not current guidance.
+
+Both interfaces are optional. A title and non-empty Markdown body suffice; no frontmatter,
 fixed headings, labels, evidence form or task association is required. Preserve
 known conditions, evidence and uncertainty. Neither lookup nor capture is a
 prerequisite or completion step. A search miss does not prove that relevant
@@ -165,10 +172,24 @@ experience is absent.
 Local and shared results are references, not instructions, approvals or current
 environment facts. Review or release does not confer authority. Agents assess
 relevance and reuse existing evidence with checks proportional to change.
+Saving current knowledge does not certify its correctness or freshness. Agents
+assess conclusions against current code and evidence. Related experiences can
+support a knowledge note through ordinary links; there is no automatic promotion.
 
-Shared releases are read-only. Project Markdown lives in `.agents/knowledge/`;
-local captures and package state stay under `.vaws-local/knowledge/`. The package
-indexes content. Hooks reuse the normal task summary, and manual capture can
+Shared releases are read-only and preserve the public corpus's separate
+`corpus/knowledge/` and `corpus/experience/` sources. Releases must use
+`vaws-knowledge-release/2` with `content.layout: kinds/v1`; older remote packs
+must be rebuilt. Queries do not fall back to untyped release contents.
+Project preparation uses `.agents/knowledge/` and `.agents/experiences/`;
+local captures use `.vaws-local/knowledge/candidate/` and
+`.vaws-local/experience/candidate/`. `experience.layers` configures independent
+experience roots when needed. Existing configured roots remain authoritative.
+The package keeps separate retrieval namespaces in one shared OpenViking instance
+under `.vaws-local/knowledge/instance/`. Each query searches only its selected store,
+with shared/project/candidate describing provenance within that store.
+Existing local notes are not automatically moved or reclassified; their presence
+does not assert validation against current main.
+Hooks save the normal task summary as an experience, and manual capture can
 reuse useful existing text without an extra summary or publishing follow-up.
 
 Dependency sync asks the package to prepare its model and index. MCP maintains

--- a/docs/target-state.md
+++ b/docs/target-state.md
@@ -174,8 +174,10 @@ redacted contribution PR rather than writing a release.
 Optional `experience_feedback(ref, vote)` records `+1` when a published case
 helped or `-1` when it misled the work. No reason or extra summary is required.
 The package reuses configured GitHub sharing and one feedback Issue per public
-experience, with reactions per GitHub account. Repeated votes do not accumulate;
-switching the vote replaces that account's previous reaction. Feedback neither
+experience, with a minimal comment for each usage event. Both `+1` and `-1` can
+accumulate repeatedly from the same account and never remove earlier events.
+Omit optional `request_id` for new feedback; reuse a failed call's returned ID
+only to retry that event without adding another count. Feedback neither
 changes the case text nor certifies correctness, freshness or current applicability.
 It is not a task completion step.
 

--- a/docs/target-state.md
+++ b/docs/target-state.md
@@ -163,6 +163,22 @@ when code or conditions change; experiences can preserve old implementations as
 historical context. Correct mistaken interpretations while retaining the observed
 evidence. Historical commands are investigation clues, not current guidance.
 
+Knowledge is maintained by fixed semantic category/entry paths; equal text does
+not merge different entries. Experience retains a stable case ID. Corrections
+keep the public path, including existing filenames: optional capture `ref`
+updates a local candidate even when its title changes, while `public_relpath`
+selects a classified knowledge entry or an existing shared experience. New
+knowledge paths can be created explicitly; shared corrections use the normal
+redacted contribution PR rather than writing a release.
+
+Optional `experience_feedback(ref, vote)` records `+1` when a published case
+helped or `-1` when it misled the work. No reason or extra summary is required.
+The package reuses configured GitHub sharing and one feedback Issue per public
+experience, with reactions per GitHub account. Repeated votes do not accumulate;
+switching the vote replaces that account's previous reaction. Feedback neither
+changes the case text nor certifies correctness, freshness or current applicability.
+It is not a task completion step.
+
 Both interfaces are optional. A title and non-empty Markdown body suffice; no frontmatter,
 fixed headings, labels, evidence form or task association is required. Preserve
 known conditions, evidence and uncertainty. Neither lookup nor capture is a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ dependencies = [
   "Pillow>=11",
   "vaws-remote-dev==0.7.0",
   "vaws-coordinator==0.4.0",
-  "vaws-knowledge==0.5.0",
+  "vaws-knowledge==0.6.0",
 ]
 
 [dependency-groups]
@@ -23,7 +23,7 @@ package = false
 [tool.uv.sources]
 vaws-remote-dev = { git = "https://github.com/vllm-ascend-workspace/remote-dev", rev = "2de5cc32c5f3dd517e698cadfb1f9ed23589b1aa" }
 vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", rev = "6caa71ef6664d6d6b9cbb0e859893efec182d7f4" }
-vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", rev = "c95293836a3b595c13a80189197d44a2980c9fbd" }
+vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", rev = "ff202f5df0a11937d50439e4909b9b956de26b0a" }
 
 [tool.pytest.ini_options]
 pythonpath = [".agents/lib"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ package = false
 [tool.uv.sources]
 vaws-remote-dev = { git = "https://github.com/vllm-ascend-workspace/remote-dev", rev = "2de5cc32c5f3dd517e698cadfb1f9ed23589b1aa" }
 vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", rev = "6caa71ef6664d6d6b9cbb0e859893efec182d7f4" }
-vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", rev = "ff202f5df0a11937d50439e4909b9b956de26b0a" }
+vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", rev = "677a0055d00c1c4315400cb47f2becf49be8ca02" }
 
 [tool.pytest.ini_options]
 pythonpath = [".agents/lib"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ package = false
 [tool.uv.sources]
 vaws-remote-dev = { git = "https://github.com/vllm-ascend-workspace/remote-dev", rev = "2de5cc32c5f3dd517e698cadfb1f9ed23589b1aa" }
 vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", rev = "6caa71ef6664d6d6b9cbb0e859893efec182d7f4" }
-vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", rev = "677a0055d00c1c4315400cb47f2becf49be8ca02" }
+vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", rev = "ac8c227de46ee19fe9cf6bcbb7cfc856d28740e5" }
 
 [tool.pytest.ini_options]
 pythonpath = [".agents/lib"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ package = false
 [tool.uv.sources]
 vaws-remote-dev = { git = "https://github.com/vllm-ascend-workspace/remote-dev", rev = "2de5cc32c5f3dd517e698cadfb1f9ed23589b1aa" }
 vaws-coordinator = { git = "https://github.com/vllm-ascend-workspace/vaws-coordinator", rev = "6caa71ef6664d6d6b9cbb0e859893efec182d7f4" }
-vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", rev = "ac8c227de46ee19fe9cf6bcbb7cfc856d28740e5" }
+vaws-knowledge = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge", rev = "cf5824dff7bc21b783ce6e12c605d7530b8ef651" }
 
 [tool.pytest.ini_options]
 pythonpath = [".agents/lib"]

--- a/uv.lock
+++ b/uv.lock
@@ -4249,7 +4249,7 @@ dependencies = [
 [[package]]
 name = "vaws-knowledge"
 version = "0.6.0"
-source = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=ac8c227de46ee19fe9cf6bcbb7cfc856d28740e5#ac8c227de46ee19fe9cf6bcbb7cfc856d28740e5" }
+source = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=cf5824dff7bc21b783ce6e12c605d7530b8ef651#cf5824dff7bc21b783ce6e12c605d7530b8ef651" }
 dependencies = [
     { name = "fastembed" },
     { name = "openviking" },
@@ -4285,7 +4285,7 @@ dev = [
 requires-dist = [
     { name = "pillow", specifier = ">=11" },
     { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=6caa71ef6664d6d6b9cbb0e859893efec182d7f4" },
-    { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=ac8c227de46ee19fe9cf6bcbb7cfc856d28740e5" },
+    { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=cf5824dff7bc21b783ce6e12c605d7530b8ef651" },
     { name = "vaws-remote-dev", git = "https://github.com/vllm-ascend-workspace/remote-dev?rev=2de5cc32c5f3dd517e698cadfb1f9ed23589b1aa" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -4249,7 +4249,7 @@ dependencies = [
 [[package]]
 name = "vaws-knowledge"
 version = "0.6.0"
-source = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=ff202f5df0a11937d50439e4909b9b956de26b0a#ff202f5df0a11937d50439e4909b9b956de26b0a" }
+source = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=677a0055d00c1c4315400cb47f2becf49be8ca02#677a0055d00c1c4315400cb47f2becf49be8ca02" }
 dependencies = [
     { name = "fastembed" },
     { name = "openviking" },
@@ -4285,7 +4285,7 @@ dev = [
 requires-dist = [
     { name = "pillow", specifier = ">=11" },
     { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=6caa71ef6664d6d6b9cbb0e859893efec182d7f4" },
-    { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=ff202f5df0a11937d50439e4909b9b956de26b0a" },
+    { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=677a0055d00c1c4315400cb47f2becf49be8ca02" },
     { name = "vaws-remote-dev", git = "https://github.com/vllm-ascend-workspace/remote-dev?rev=2de5cc32c5f3dd517e698cadfb1f9ed23589b1aa" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -4249,7 +4249,7 @@ dependencies = [
 [[package]]
 name = "vaws-knowledge"
 version = "0.6.0"
-source = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=677a0055d00c1c4315400cb47f2becf49be8ca02#677a0055d00c1c4315400cb47f2becf49be8ca02" }
+source = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=ac8c227de46ee19fe9cf6bcbb7cfc856d28740e5#ac8c227de46ee19fe9cf6bcbb7cfc856d28740e5" }
 dependencies = [
     { name = "fastembed" },
     { name = "openviking" },
@@ -4285,7 +4285,7 @@ dev = [
 requires-dist = [
     { name = "pillow", specifier = ">=11" },
     { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=6caa71ef6664d6d6b9cbb0e859893efec182d7f4" },
-    { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=677a0055d00c1c4315400cb47f2becf49be8ca02" },
+    { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=ac8c227de46ee19fe9cf6bcbb7cfc856d28740e5" },
     { name = "vaws-remote-dev", git = "https://github.com/vllm-ascend-workspace/remote-dev?rev=2de5cc32c5f3dd517e698cadfb1f9ed23589b1aa" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -4248,8 +4248,8 @@ dependencies = [
 
 [[package]]
 name = "vaws-knowledge"
-version = "0.5.0"
-source = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=c95293836a3b595c13a80189197d44a2980c9fbd#c95293836a3b595c13a80189197d44a2980c9fbd" }
+version = "0.6.0"
+source = { git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=ff202f5df0a11937d50439e4909b9b956de26b0a#ff202f5df0a11937d50439e4909b9b956de26b0a" }
 dependencies = [
     { name = "fastembed" },
     { name = "openviking" },
@@ -4285,7 +4285,7 @@ dev = [
 requires-dist = [
     { name = "pillow", specifier = ">=11" },
     { name = "vaws-coordinator", git = "https://github.com/vllm-ascend-workspace/vaws-coordinator?rev=6caa71ef6664d6d6b9cbb0e859893efec182d7f4" },
-    { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=c95293836a3b595c13a80189197d44a2980c9fbd" },
+    { name = "vaws-knowledge", git = "https://github.com/vllm-ascend-workspace/vaws-knowledge?rev=ff202f5df0a11937d50439e4909b9b956de26b0a" },
     { name = "vaws-remote-dev", git = "https://github.com/vllm-ascend-workspace/remote-dev?rev=2de5cc32c5f3dd517e698cadfb1f9ed23589b1aa" },
 ]
 


### PR DESCRIPTION
Wire separate maintained knowledge and historical experience stores into workspace configuration and native clients. Current conclusions use knowledge interfaces; historical cases and normal session summaries use experience interfaces. Both reuse the package-owned OpenViking instance with separate retrieval namespaces.

Consume stable document identity and the optional `experience_feedback(ref, vote)` tool. Knowledge uses fixed semantic entry paths; experience retains case IDs. Capture can revise an existing candidate or explicitly selected public document without renaming it. Feedback records each use as a minimal GitHub Issue comment with no required reason. Both positive and negative feedback from the same account accumulate independently; failed requests can retry the returned event ID without adding another count. It is optional and does not certify correctness or change retrieval ranking.

Depends on [vaws-knowledge #25](https://github.com/vllm-ascend-workspace/vaws-knowledge/pull/25). Pin `vaws-knowledge==0.6.0` to canonical commit `cf5824dff7bc21b783ce6e12c605d7530b8ef651`. The remote release contract intentionally breaks compatibility: only `vaws-knowledge-release/2` with `content.layout: kinds/v1` is accepted; older packs must be rebuilt.

Validation: lock regeneration/check and package-only immutable environment preparation succeeded. The seven knowledge test modules plus dependency tests passed against the exact installed package revision (72 passed, 1 native-Windows-only case skipped). `git diff --check` passed. Linux, macOS and Windows CI all passed on `b644b8a60b63913e412e7251c2d1b3c9133ad7db`.
